### PR TITLE
feat: text track settings colour test

### DIFF
--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -526,12 +526,12 @@ class TextTrackSettings extends ModalDialog {
    */
   setValues(values) {
     Obj.each(selectConfigs, (config, key) => {
-      console.log("joe test - config:", config)
-      console.log("joe test - key:", key)
-      console.log("joe test - this.$(config.selector):", this.$(config.selector))
-      console.log("joe test - values[key]:", values[key])
-      console.log("joe test - config.parser:", config.parser)
-      console.log("joe test /")
+      log.info('joe test - config:', config);
+      log.info('joe test - key:', key);
+      log.info('joe test - this.$(config.selector):', this.$(config.selector));
+      log.info('joe test - values[key]:', values[key]);
+      log.info('joe test - config.parser:', config.parser);
+      log.info('joe test /');
       setSelectedOption(this.$(config.selector), values[key], config.parser);
     });
   }

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -205,6 +205,9 @@ function parseOptionValue(value, parser) {
 function getSelectedOptionValue(el, parser) {
   const value = el.options[el.options.selectedIndex].value;
 
+  // this.player_.log("joe test - getSelectedOption")
+  // this.player_.log("joe test - getSelectedOption, value:", value)
+
   return parseOptionValue(value, parser);
 }
 
@@ -224,11 +227,14 @@ function getSelectedOptionValue(el, parser) {
  * @private
  */
 function setSelectedOption(el, value, parser) {
+  this.player_.log('joe test - setSelectedOption');
+  this.player_.log('joe test - setSelectedOption, value:', value);
   if (!value) {
     return;
   }
 
   for (let i = 0; i < el.options.length; i++) {
+    this.player_.log('joe test - setSelectedOption, parseOptionValue(el.options[i].value, parser):', parseOptionValue(el.options[i].value, parser));
     if (parseOptionValue(el.options[i].value, parser) === value) {
       el.selectedIndex = i;
       break;
@@ -508,13 +514,13 @@ class TextTrackSettings extends ModalDialog {
    */
   getValues() {
     return Obj.reduce(selectConfigs, (accum, config, key) => {
-      this.player_.log('joe test - getValues');
-      this.player_.log('joe test - accum:', accum);
-      this.player_.log('joe test - config:', config);
-      this.player_.log('joe test - key:', key);
-      this.player_.log('joe test - this.$(config.selector):', this.$(config.selector));
-      this.player_.log('joe test - config.parser:', config.parser);
-      this.player_.log('joe test /');
+      // this.player_.log('joe test - getValues');
+      // this.player_.log('joe test - accum:', accum);
+      // this.player_.log('joe test - config:', config);
+      // this.player_.log('joe test - key:', key);
+      // this.player_.log('joe test - this.$(config.selector):', this.$(config.selector));
+      // this.player_.log('joe test - config.parser:', config.parser);
+      // this.player_.log('joe test /');
       const value = getSelectedOptionValue(this.$(config.selector), config.parser);
 
       if (value !== undefined) {
@@ -533,13 +539,13 @@ class TextTrackSettings extends ModalDialog {
    */
   setValues(values) {
     Obj.each(selectConfigs, (config, key) => {
-      this.player_.log('joe test - setValues');
-      this.player_.log('joe test - config:', config);
-      this.player_.log('joe test - key:', key);
-      this.player_.log('joe test - this.$(config.selector):', this.$(config.selector));
-      this.player_.log('joe test - values[key]:', values[key]);
-      this.player_.log('joe test - config.parser:', config.parser);
-      this.player_.log('joe test /');
+      // this.player_.log('joe test - setValues');
+      // this.player_.log('joe test - config:', config);
+      // this.player_.log('joe test - key:', key);
+      // this.player_.log('joe test - this.$(config.selector):', this.$(config.selector));
+      // this.player_.log('joe test - values[key]:', values[key]);
+      // this.player_.log('joe test - config.parser:', config.parser);
+      // this.player_.log('joe test /');
       setSelectedOption(this.$(config.selector), values[key], config.parser);
     });
   }

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -131,6 +131,8 @@ const selectConfigs = {
     // not sure if there was a particular reason for sometimes returning null,
     // but this change doesn't seem to break anything.
     // parser: (v) => Number(v)
+    // Joe note: despite claiming to return null here, it seems this returns
+    // undefined? Looking into parseOptionValue for clues as to why.
     parser: (v) => v === '1.00' ? null : Number(v)
   },
 
@@ -182,9 +184,15 @@ selectConfigs.windowColor.options = selectConfigs.backgroundColor.options;
  *
  * @private
  */
-function parseOptionValue(value, parser) {
+function parseOptionValue(value, parser, player) {
+  if (player) {
+    player.log('joe test - parseOptionValue, value:', value);
+  }
   if (parser) {
     value = parser(value);
+    if (player) {
+      player.log('joe test - parseOptionValue, parser(value):', parser(value));
+    }
   }
 
   if (value && value !== 'none') {
@@ -248,8 +256,11 @@ function setSelectedOption(el, value, parser, player) {
   }
 
   for (let i = 0; i < el.options.length; i++) {
+    // Joe note: remember, this is comparing the value of EACH option in the
+    // list, *after* parsing, with the value supplied to the setSelectedOption
+    // call. i.e. the post-parser value and the supplie value must match.
     player.log('joe test - setSelectedOption, parseOptionValue(el.options[i].value, parser):', parseOptionValue(el.options[i].value, parser));
-    if (parseOptionValue(el.options[i].value, parser) === value) {
+    if (parseOptionValue(el.options[i].value, parser, this.player_) === value) {
       el.selectedIndex = i;
       break;
     }

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -205,8 +205,7 @@ function parseOptionValue(value, parser) {
 function getSelectedOptionValue(el, parser) {
   const value = el.options[el.options.selectedIndex].value;
 
-  // this.player_.log("joe test - getSelectedOption")
-  // this.player_.log("joe test - getSelectedOption, value:", value)
+  this.player_.log('joe test - getSelectedOption, value:', value, ' | parseOptionValue(value, parser):', parseOptionValue(value, parser));
 
   return parseOptionValue(value, parser);
 }
@@ -227,8 +226,7 @@ function getSelectedOptionValue(el, parser) {
  * @private
  */
 function setSelectedOption(el, value, parser, player) {
-  player.log('joe test - setSelectedOption');
-  player.log('joe test - setSelectedOption, value:', value);
+  player.log('joe test - setSelectedOption, el:', el, ' | value:', value);
   if (!value) {
     return;
   }

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -526,6 +526,12 @@ class TextTrackSettings extends ModalDialog {
    */
   setValues(values) {
     Obj.each(selectConfigs, (config, key) => {
+      console.log("joe test - config:", config)
+      console.log("joe test - key:", key)
+      console.log("joe test - this.$(config.selector):", this.$(config.selector))
+      console.log("joe test - values[key]:", values[key])
+      console.log("joe test - config.parser:", config.parser)
+      console.log("joe test /")
       setSelectedOption(this.$(config.selector), values[key], config.parser);
     });
   }

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -526,12 +526,12 @@ class TextTrackSettings extends ModalDialog {
    */
   setValues(values) {
     Obj.each(selectConfigs, (config, key) => {
-      log.info('joe test - config:', config);
-      log.info('joe test - key:', key);
-      log.info('joe test - this.$(config.selector):', this.$(config.selector));
-      log.info('joe test - values[key]:', values[key]);
-      log.info('joe test - config.parser:', config.parser);
-      log.info('joe test /');
+      this.player_.log('joe test - config:', config);
+      this.player_.log('joe test - key:', key);
+      this.player_.log('joe test - this.$(config.selector):', this.$(config.selector));
+      this.player_.log('joe test - values[key]:', values[key]);
+      this.player_.log('joe test - config.parser:', config.parser);
+      this.player_.log('joe test /');
       setSelectedOption(this.$(config.selector), values[key], config.parser);
     });
   }

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -260,7 +260,7 @@ function setSelectedOption(el, value, parser, player) {
     // list, *after* parsing, with the value supplied to the setSelectedOption
     // call. i.e. the post-parser value and the supplie value must match.
     player.log('joe test - setSelectedOption, parseOptionValue(el.options[i].value, parser):', parseOptionValue(el.options[i].value, parser));
-    if (parseOptionValue(el.options[i].value, parser, this.player_) === value) {
+    if (parseOptionValue(el.options[i].value, parser, player) === value) {
       el.selectedIndex = i;
       break;
     }

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -208,8 +208,10 @@ function parseOptionValue(value, parser) {
  *
  * @private
  */
-function getSelectedOptionValue(el, parser) {
+function getSelectedOptionValue(el, parser, player) {
   const value = el.options[el.options.selectedIndex].value;
+
+  player.log('joe test - setSelectedOption, value:', value, ' | parseOptionValue(value, parser):', parseOptionValue(value, parser));
 
   return parseOptionValue(value, parser);
 }
@@ -229,7 +231,8 @@ function getSelectedOptionValue(el, parser) {
  *
  * @private
  */
-function setSelectedOption(el, value, parser) {
+function setSelectedOption(el, value, parser, player) {
+  player.log('joe test - setSelectedOption, value:', value);
   // Joe note: there's a problem here (given how we use VJS's "not really real
   // API"). This tests if "value" is truthy, but the (default) fontPercent
   // parser (above) will return "null" for 1.00 (100%). This means the for
@@ -245,6 +248,7 @@ function setSelectedOption(el, value, parser) {
   }
 
   for (let i = 0; i < el.options.length; i++) {
+    player.log('joe test - setSelectedOption, parseOptionValue(el.options[i].value, parser):', parseOptionValue(el.options[i].value, parser));
     if (parseOptionValue(el.options[i].value, parser) === value) {
       el.selectedIndex = i;
       break;
@@ -524,13 +528,6 @@ class TextTrackSettings extends ModalDialog {
    */
   getValues() {
     return Obj.reduce(selectConfigs, (accum, config, key) => {
-      // this.player_.log('joe test - getValues');
-      // this.player_.log('joe test - accum:', accum);
-      // this.player_.log('joe test - config:', config);
-      // this.player_.log('joe test - key:', key);
-      // this.player_.log('joe test - this.$(config.selector):', this.$(config.selector));
-      // this.player_.log('joe test - config.parser:', config.parser);
-      // this.player_.log('joe test /');
       const value = getSelectedOptionValue(this.$(config.selector), config.parser, this.player_);
 
       if (value !== undefined) {
@@ -549,13 +546,6 @@ class TextTrackSettings extends ModalDialog {
    */
   setValues(values) {
     Obj.each(selectConfigs, (config, key) => {
-      // this.player_.log('joe test - setValues');
-      // this.player_.log('joe test - config:', config);
-      // this.player_.log('joe test - key:', key);
-      // this.player_.log('joe test - this.$(config.selector):', this.$(config.selector));
-      // this.player_.log('joe test - values[key]:', values[key]);
-      // this.player_.log('joe test - config.parser:', config.parser);
-      // this.player_.log('joe test /');
       setSelectedOption(this.$(config.selector), values[key], config.parser, this.player_);
     });
   }

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -508,6 +508,13 @@ class TextTrackSettings extends ModalDialog {
    */
   getValues() {
     return Obj.reduce(selectConfigs, (accum, config, key) => {
+      this.player_.log('joe test - getValues');
+      this.player_.log('joe test - accum:', accum);
+      this.player_.log('joe test - config:', config);
+      this.player_.log('joe test - key:', key);
+      this.player_.log('joe test - this.$(config.selector):', this.$(config.selector));
+      this.player_.log('joe test - config.parser:', config.parser);
+      this.player_.log('joe test /');
       const value = getSelectedOptionValue(this.$(config.selector), config.parser);
 
       if (value !== undefined) {
@@ -526,6 +533,7 @@ class TextTrackSettings extends ModalDialog {
    */
   setValues(values) {
     Obj.each(selectConfigs, (config, key) => {
+      this.player_.log('joe test - setValues');
       this.player_.log('joe test - config:', config);
       this.player_.log('joe test - key:', key);
       this.player_.log('joe test - this.$(config.selector):', this.$(config.selector));

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -205,7 +205,7 @@ function parseOptionValue(value, parser) {
 function getSelectedOptionValue(el, parser, player) {
   const value = el.options[el.options.selectedIndex].value;
 
-  this.player_.log('joe test - getSelectedOption, value:', value, ' | parseOptionValue(value, parser):', parseOptionValue(value, parser));
+  player.log('joe test - getSelectedOption, value:', value, ' | parseOptionValue(value, parser):', parseOptionValue(value, parser));
 
   return parseOptionValue(value, parser);
 }

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -133,7 +133,7 @@ const selectConfigs = {
     // parser: (v) => Number(v)
     // Joe note: despite claiming to return null here, it seems this returns
     // undefined? Looking into parseOptionValue for clues as to why.
-    parser: (v) => v === '1.00' ? null : Number(v)
+    parser: (v) => v === '1.00' ? 'foobar' : Number(v)
   },
 
   textOpacity: {
@@ -240,7 +240,7 @@ function getSelectedOptionValue(el, parser, player) {
  * @private
  */
 function setSelectedOption(el, value, parser, player) {
-  player.log('joe test - setSelectedOption, value:', value);
+  player.log('joe test - setSelectedOption, el:', el, ' | value:', value);
   // Joe note: there's a problem here (given how we use VJS's "not really real
   // API"). This tests if "value" is truthy, but the (default) fontPercent
   // parser (above) will return "null" for 1.00 (100%). This means the for

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -202,7 +202,7 @@ function parseOptionValue(value, parser) {
  *
  * @private
  */
-function getSelectedOptionValue(el, parser) {
+function getSelectedOptionValue(el, parser, player) {
   const value = el.options[el.options.selectedIndex].value;
 
   this.player_.log('joe test - getSelectedOption, value:', value, ' | parseOptionValue(value, parser):', parseOptionValue(value, parser));
@@ -519,7 +519,7 @@ class TextTrackSettings extends ModalDialog {
       // this.player_.log('joe test - this.$(config.selector):', this.$(config.selector));
       // this.player_.log('joe test - config.parser:', config.parser);
       // this.player_.log('joe test /');
-      const value = getSelectedOptionValue(this.$(config.selector), config.parser);
+      const value = getSelectedOptionValue(this.$(config.selector), config.parser, this.player_);
 
       if (value !== undefined) {
         accum[key] = value;

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -226,15 +226,15 @@ function getSelectedOptionValue(el, parser) {
  *
  * @private
  */
-function setSelectedOption(el, value, parser) {
-  this.player_.log('joe test - setSelectedOption');
-  this.player_.log('joe test - setSelectedOption, value:', value);
+function setSelectedOption(el, value, parser, player) {
+  player.log('joe test - setSelectedOption');
+  player.log('joe test - setSelectedOption, value:', value);
   if (!value) {
     return;
   }
 
   for (let i = 0; i < el.options.length; i++) {
-    this.player_.log('joe test - setSelectedOption, parseOptionValue(el.options[i].value, parser):', parseOptionValue(el.options[i].value, parser));
+    player.log('joe test - setSelectedOption, parseOptionValue(el.options[i].value, parser):', parseOptionValue(el.options[i].value, parser));
     if (parseOptionValue(el.options[i].value, parser) === value) {
       el.selectedIndex = i;
       break;
@@ -546,7 +546,7 @@ class TextTrackSettings extends ModalDialog {
       // this.player_.log('joe test - values[key]:', values[key]);
       // this.player_.log('joe test - config.parser:', config.parser);
       // this.player_.log('joe test /');
-      setSelectedOption(this.$(config.selector), values[key], config.parser);
+      setSelectedOption(this.$(config.selector), values[key], config.parser, this.player_);
     });
   }
 

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -18,6 +18,7 @@ const COLOR_MAGENTA = ['#F0F', 'Magenta'];
 const COLOR_RED = ['#F00', 'Red'];
 const COLOR_WHITE = ['#FFF', 'White'];
 const COLOR_YELLOW = ['#FF0', 'Yellow'];
+const COLOR_ORANGE = ['#FA0', 'Orange'];
 
 const OPACITY_OPAQUE = ['1', 'Opaque'];
 const OPACITY_SEMI = ['0.5', 'Semi-Transparent'];
@@ -47,7 +48,8 @@ const selectConfigs = {
       COLOR_BLUE,
       COLOR_YELLOW,
       COLOR_MAGENTA,
-      COLOR_CYAN
+      COLOR_CYAN,
+      COLOR_ORANGE
     ]
   },
 
@@ -74,7 +76,8 @@ const selectConfigs = {
       COLOR_BLUE,
       COLOR_YELLOW,
       COLOR_MAGENTA,
-      COLOR_CYAN
+      COLOR_CYAN,
+      COLOR_ORANGE
     ]
   },
 

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -125,7 +125,8 @@ const selectConfigs = {
       ['4.00', '400%']
     ],
     default: 2,
-    parser: (v) => v === '1.00' ? null : Number(v)
+    parser: (v) => Number(v)
+    // parser: (v) => v === '1.00' ? null : Number(v)
   },
 
   textOpacity: {
@@ -227,9 +228,17 @@ function getSelectedOptionValue(el, parser, player) {
  */
 function setSelectedOption(el, value, parser, player) {
   player.log('joe test - setSelectedOption, el:', el, ' | value:', value);
+  // Joe note: OK, I *think* the problem (for me) is here: this tests if value
+  // is truthy, but the fontPercent parser will return null for 1.00 (100%) -
+  // meaning the for loop below will *never* match the value we're trying to
+  // set. You can either change this if OR change the parser (I'm not sure
+  // why it wants to work with null, anyway?)
   if (!value) {
     return;
   }
+  // if (value === undefined) {
+  //   return;
+  // }
 
   for (let i = 0; i < el.options.length; i++) {
     player.log('joe test - setSelectedOption, parseOptionValue(el.options[i].value, parser):', parseOptionValue(el.options[i].value, parser));


### PR DESCRIPTION
Add a test colour to the TextTrackSettings constants.

Aim: see if this allows use of this class's API to set subtitles to the given test colour.

Hypothesis: based on current use of API, only setting a colour from those listed here will work.

More broadly: I suspect other aspects of subtitles might follow similar constraints. So if this test is successful, we hopefully have a quick and consistent way to change those constraints.